### PR TITLE
User: Fix du crash lors du marshall du mot de passe

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -36,5 +36,5 @@ func (p *Password) UnmarshalJSON(b []byte) error {
 }
 
 func (p Password) MarshalJSON() ([]byte, error) {
-	return nil, nil
+	return json.Marshal("")
 }


### PR DESCRIPTION
L'erreur était bien due au fait de passer un tableau de bytes vide, que gin-gonic a interprété comme `"{..., pass:}"`, d'où la cause du panic.
Résolu en appelant tout simplement la méthode `json.Marshall()` sur un string vide

Signed-off-by: Anass 'Serdok' Lahnin <l.anass.pro@gmail.com>